### PR TITLE
AudioRecorderDelegate: replace class with AnyObject

### DIFF
--- a/Cubic/CubicExample/AudioRecorder.swift
+++ b/Cubic/CubicExample/AudioRecorder.swift
@@ -22,7 +22,7 @@ import AVFoundation
 import Cubic
 import GRPC
 
-protocol AudioRecorderDelegate: class {
+protocol AudioRecorderDelegate: AnyObject {
     
     func audioRecorderDidReceiveRecognitionResponse(_ response: Cobaltspeech_Cubic_RecognitionResponse)
     


### PR DESCRIPTION
Fixed the following warning:

Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead